### PR TITLE
Anchor CI to use Conan 1.59.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install pip packages
         run: |
           python -m pip install --upgrade pip
-          pip install conan
+          pip install conan==1.59.0
       - name: Create Conan default profile
         run: |
           conan profile new default --detect


### PR DESCRIPTION
Conan 2.0.0 has been released, which is a breaking change.