### PR TITLE
Add `FLEX_INCLUDE_DIRS` just to the target that needs them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,6 @@ find_program(M4 m4)
 
 # Find FLEX
 find_package(FLEX 2.6.0 REQUIRED)
-include_directories(BEFORE SYSTEM ${FLEX_INCLUDE_DIRS})
 if (NOT DEFINED FLEX_EXECUTABLE)
   find_program(FLEX_EXECUTABLE flex)
 endif()

--- a/lib/Parser/CMakeLists.txt
+++ b/lib/Parser/CMakeLists.txt
@@ -165,7 +165,7 @@ if(BUILD_SHARED_LIBS)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
       $<BUILD_INTERFACE:${OPENQASM_BINARY_DIR}/include>)
-  target_link_libraries(${SHARED_LIB} PUBLIC ${OPENQASM_TARGET_DIAG_SHARED} mpc::mpc mpfr::mpfr gmp::gmp)
+  target_link_libraries(${SHARED_LIB} PUBLIC ${OPENQASM_TARGET_DIAG_SHARED} mpc::mpc mpfr::mpfr gmp::gmp flex::flex)
   list(APPEND CMAKE_TARGETS ${SHARED_LIB})
   target_compile_features(${SHARED_LIB} PUBLIC ${REQUIRED_FEATURES})
 endif()
@@ -185,7 +185,7 @@ if (BUILD_STATIC_LIBS)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
       $<BUILD_INTERFACE:${OPENQASM_BINARY_DIR}/include>)
-  target_link_libraries(${STATIC_LIB} PUBLIC ${OPENQASM_TARGET_DIAG_STATIC} mpc::mpc mpfr::mpfr gmp::gmp)
+  target_link_libraries(${STATIC_LIB} PUBLIC ${OPENQASM_TARGET_DIAG_STATIC} mpc::mpc mpfr::mpfr gmp::gmp flex::flex)
   list(APPEND CMAKE_TARGETS ${STATIC_LIB})
   target_compile_features(${STATIC_LIB} PUBLIC ${REQUIRED_FEATURES})
 endif()

--- a/lib/Parser/CMakeLists.txt
+++ b/lib/Parser/CMakeLists.txt
@@ -164,8 +164,9 @@ if(BUILD_SHARED_LIBS)
       $<BUILD_INTERFACE:${OPENQASM_INCLUDE_DIR}>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-      $<BUILD_INTERFACE:${OPENQASM_BINARY_DIR}/include>)
-  target_link_libraries(${SHARED_LIB} PUBLIC ${OPENQASM_TARGET_DIAG_SHARED} mpc::mpc mpfr::mpfr gmp::gmp flex::flex)
+      $<BUILD_INTERFACE:${OPENQASM_BINARY_DIR}/include>
+      $<BUILD_INTERFACE:${FLEX_INCLUDE_DIRS}>)
+  target_link_libraries(${SHARED_LIB} PUBLIC ${OPENQASM_TARGET_DIAG_SHARED} mpc::mpc mpfr::mpfr gmp::gmp)
   list(APPEND CMAKE_TARGETS ${SHARED_LIB})
   target_compile_features(${SHARED_LIB} PUBLIC ${REQUIRED_FEATURES})
 endif()
@@ -184,8 +185,9 @@ if (BUILD_STATIC_LIBS)
       $<BUILD_INTERFACE:${OPENQASM_INCLUDE_DIR}>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-      $<BUILD_INTERFACE:${OPENQASM_BINARY_DIR}/include>)
-  target_link_libraries(${STATIC_LIB} PUBLIC ${OPENQASM_TARGET_DIAG_STATIC} mpc::mpc mpfr::mpfr gmp::gmp flex::flex)
+      $<BUILD_INTERFACE:${OPENQASM_BINARY_DIR}/include>
+      $<BUILD_INTERFACE:${FLEX_INCLUDE_DIRS}>)
+  target_link_libraries(${STATIC_LIB} PUBLIC ${OPENQASM_TARGET_DIAG_STATIC} mpc::mpc mpfr::mpfr gmp::gmp)
   list(APPEND CMAKE_TARGETS ${STATIC_LIB})
   target_compile_features(${STATIC_LIB} PUBLIC ${REQUIRED_FEATURES})
 endif()


### PR DESCRIPTION
~~Generated files by Flex include `FlexLexer.h` file, so they need to find it from the declared dependency (not from the system). We need to add here target `flex::flex` so include directories are propagated properly.~~ (https://github.com/conan-io/conan-center-index/issues/1813)

Add `FLEX_INCLUDE_DIRS` just to the target that needs them