### PR TITLE
add #include <cstdint> where required

### DIFF
--- a/include/qasm/AST/ASTBase.h
+++ b/include/qasm/AST/ASTBase.h
@@ -1,6 +1,6 @@
 /* -*- coding: utf-8 -*-
  *
- * Copyright 2022 IBM RESEARCH. All Rights Reserved.
+ * Copyright 2022, 2023 IBM RESEARCH. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 #include <qasm/AST/ASTTypeEnums.h>
 #include <qasm/Diagnostic/DIAGLineCounter.h>
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <vector>

--- a/include/qasm/AST/ASTHeapSizeController.h
+++ b/include/qasm/AST/ASTHeapSizeController.h
@@ -1,6 +1,6 @@
 /* -*- coding: utf-8 -*-
  *
- * Copyright 2022 IBM RESEARCH. All Rights Reserved.
+ * Copyright 2022, 2023 IBM RESEARCH. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 #ifndef __QASM_AST_HEAP_SIZE_CONTROLLER_H
 #define __QASM_AST_HEAP_SIZE_CONTROLLER_H
 
+#include <cstdint>
 #include <string>
 
 namespace QASM {

--- a/include/qasm/Diagnostic/DIAGLineCounter.h
+++ b/include/qasm/Diagnostic/DIAGLineCounter.h
@@ -1,6 +1,6 @@
 /* -*- coding: utf-8 -*-
  *
- * Copyright 2022 IBM RESEARCH. All Rights Reserved.
+ * Copyright 2022, 2023 IBM RESEARCH. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 #ifndef __QASM_DIAG_LINE_COUNTER_H
 #define __QASM_DIAG_LINE_COUNTER_H
 
+#include <cstdint>
 #include <string>
 #include <sstream>
 #include <vector>


### PR DESCRIPTION
Some recent versions of gcc and its C++ standard library headers (e.g., in Fedora 38) change which system headers implicitly include each other, resulting in the need to explicitly include cstdint to make use of fixed width integer types (e.g., uint32_t).