### PR TITLE
fix: missing bitnot rule in UnaryOp

### DIFF
--- a/lib/AST/ASTExpressionValidator.cpp
+++ b/lib/AST/ASTExpressionValidator.cpp
@@ -730,6 +730,7 @@ bool ASTExpressionValidator::Validate(const ASTUnaryOpNode *UOp) const {
   case ASTOpTypeBinaryRightFold:
   case ASTOpTypeUnaryLeftFold:
   case ASTOpTypeUnaryRightFold:
+  case ASTOpTypeBitNot:
     return true;
     break;
   case ASTOpTypeLogicalNot:

--- a/lib/Parser/QasmParser.y
+++ b/lib/Parser/QasmParser.y
@@ -4458,6 +4458,10 @@ UnaryOp
     $$ = ASTProductionFactory::Instance().ProductionRule_300(GET_TOKEN(3), $3,
                                                              ASTOpTypeSqrt);
   }
+  | '~' Expr {
+    $$ = ASTProductionFactory::Instance().ProductionRule_300(GET_TOKEN(2), $2,
+                                                             ASTOpTypeBitNot);
+  }
   ;
 
 ArithPowExpr

--- a/tests/src/test-bitnot.qasm
+++ b/tests/src/test-bitnot.qasm
@@ -1,0 +1,19 @@
+OPENQASM 3.0;
+
+qubit $0;
+
+gate x q {}
+
+bit[4] c;
+
+c[0] = 1;
+
+// 1. BitNot assign
+c[1] = ~c[0];
+
+c[2] = measure $0;
+
+// 2. BitNot condition
+if (~c[2]) {
+    x $0;
+}


### PR DESCRIPTION
Fix https://github.com/openqasm/qe-qasm/issues/28, the root cause is the [UnaryOp ](https://github.com/openqasm/qe-qasm/blob/main/lib/Parser/QasmParser.y#L4280) cannot recognize "~"

Tested following qasm

```
OPENQASM 3.0;

qubit $0;

gate x q {}

bit[4] qc0_c0;

if ((qc0_c0[0] & qc0_c0[1] | qc0_c0[0] & qc0_c0[2] | qc0_c0[1] & qc0_c0[2]) & ~(qc0_c0[0] & qc0_c0[1] & qc0_c0[2])) {
    x $0;
}
qc0_c0[3] = measure $0;
```