### PR TITLE
Change assert and instead raise diagnostics error

### DIFF
--- a/lib/AST/ASTGates.cpp
+++ b/lib/AST/ASTGates.cpp
@@ -1133,7 +1133,7 @@ ASTGateNode::ASTGateNode(const ASTIdentifierNode *Id,
 
   if (C != Params.size()) {
     std::stringstream M;
-    M << "Inconsistent number of Params." << C;
+    M << "Inconsistent number of parameters in the gate call for the corresponding gate definition" << C;
     QasmDiagnosticEmitter::Instance().EmitDiagnostic(
         DIAGLineCounter::Instance().GetLocation(), M.str(), DiagLevel::Error);
     return;
@@ -1369,7 +1369,13 @@ ASTGateNode::ASTGateNode(const ASTIdentifierNode *Id,
     ++C;
   }
 
-  assert(C == Params.size() && "Inconsistent number of Params!");
+  if (C != Params.size()) {
+    std::stringstream M;
+    M << "Inconsistent number of parameters in the gate call for the corresponding gate definition" << C;
+    QasmDiagnosticEmitter::Instance().EmitDiagnostic(
+        DIAGLineCounter::Instance().GetLocation(), M.str(), DiagLevel::Error);
+    return;
+  }
 
   for (std::vector<ASTAngleNode *>::const_iterator I = Params.begin();
        I != Params.end(); ++I) {

--- a/lib/AST/ASTGates.cpp
+++ b/lib/AST/ASTGates.cpp
@@ -1133,7 +1133,9 @@ ASTGateNode::ASTGateNode(const ASTIdentifierNode *Id,
 
   if (C != Params.size()) {
     std::stringstream M;
-    M << "Inconsistent number of parameters in the gate call for the corresponding gate definition" << C;
+    M << "Inconsistent number of parameters in the gate call for the "
+         "corresponding gate definition"
+      << C;
     QasmDiagnosticEmitter::Instance().EmitDiagnostic(
         DIAGLineCounter::Instance().GetLocation(), M.str(), DiagLevel::Error);
     return;
@@ -1371,7 +1373,9 @@ ASTGateNode::ASTGateNode(const ASTIdentifierNode *Id,
 
   if (C != Params.size()) {
     std::stringstream M;
-    M << "Inconsistent number of parameters in the gate call for the corresponding gate definition" << C;
+    M << "Inconsistent number of parameters in the gate call for the "
+         "corresponding gate definition"
+      << C;
     QasmDiagnosticEmitter::Instance().EmitDiagnostic(
         DIAGLineCounter::Instance().GetLocation(), M.str(), DiagLevel::Error);
     return;

--- a/lib/AST/ASTGates.cpp
+++ b/lib/AST/ASTGates.cpp
@@ -1135,8 +1135,7 @@ ASTGateNode::ASTGateNode(const ASTIdentifierNode *Id,
     std::stringstream M;
     M << "Inconsistent number of Params." << C;
     QasmDiagnosticEmitter::Instance().EmitDiagnostic(
-      DIAGLineCounter::Instance().GetLocation(), M.str(),
-                                                 DiagLevel::Error);
+        DIAGLineCounter::Instance().GetLocation(), M.str(), DiagLevel::Error);
     return;
   }
 

--- a/lib/AST/ASTGates.cpp
+++ b/lib/AST/ASTGates.cpp
@@ -1133,9 +1133,9 @@ ASTGateNode::ASTGateNode(const ASTIdentifierNode *Id,
 
   if (C != Params.size()) {
     std::stringstream M;
-    M << "Inconsistent number of parameters in the gate call for the "
-         "corresponding gate definition"
-      << C;
+    M << C
+      << " inconsistent parameters in the gate call for the "
+         "corresponding gate definition";
     QasmDiagnosticEmitter::Instance().EmitDiagnostic(
         DIAGLineCounter::Instance().GetLocation(), M.str(), DiagLevel::Error);
     return;
@@ -1373,9 +1373,9 @@ ASTGateNode::ASTGateNode(const ASTIdentifierNode *Id,
 
   if (C != Params.size()) {
     std::stringstream M;
-    M << "Inconsistent number of parameters in the gate call for the "
-         "corresponding gate definition"
-      << C;
+    M << C
+      << " inconsistent parameters in the gate call for the "
+         "corresponding gate definition";
     QasmDiagnosticEmitter::Instance().EmitDiagnostic(
         DIAGLineCounter::Instance().GetLocation(), M.str(), DiagLevel::Error);
     return;

--- a/lib/AST/ASTGates.cpp
+++ b/lib/AST/ASTGates.cpp
@@ -1131,7 +1131,14 @@ ASTGateNode::ASTGateNode(const ASTIdentifierNode *Id,
     ++C;
   }
 
-  assert(C == Params.size() && "Inconsistent number of Params!");
+  if (C != Params.size()) {
+    std::stringstream M;
+    M << "Inconsistent number of Params." << C;
+    QasmDiagnosticEmitter::Instance().EmitDiagnostic(
+      DIAGLineCounter::Instance().GetLocation(), M.str(),
+                                                 DiagLevel::Error);
+    return;
+  }
 
   C = 0;
   Ty = ASTTypeUndefined;


### PR DESCRIPTION
Assertions cause EOFFailure in the compiler and this PR fixes one such assert.