### PR TITLE
Add ASTOpTypeBitNot to mangler

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -644,6 +644,10 @@ void ASTMangler::Init() {
             {"or", 2},
         }, // bitwise or
         {
+            ASTOpTypeBitNot,
+            {"bN", 2},
+        }, // bitwise not
+        {
             ASTOpTypeXor,
             {"eo", 2},
         }, // xor

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -680,3 +680,5 @@ add_test(NAME t00335
          COMMAND ${BASH} -c "${OPENQASM_TEST_PROGRAM} -I${OPENQASM_TEST_INCDIR} ${OPENQASM_TEST_SRCDIR}/test-nested-elseif.qasm > ${CMAKE_BINARY_DIR}/tests/test-nested-elseif.qasm.out 2>&1")
 add_test(NAME t00336
          COMMAND ${BASH} -c "${OPENQASM_TEST_PROGRAM} -I${OPENQASM_TEST_INCDIR} ${OPENQASM_TEST_SRCDIR}/test-multi-nested-elseif.qasm > ${CMAKE_BINARY_DIR}/tests/test-multi-nested-elseif.qasm.out 2>&1")
+add_test(NAME t00337
+         COMMAND ${BASH} -c "${OPENQASM_TEST_PROGRAM} -I${OPENQASM_TEST_INCDIR} ${OPENQASM_TEST_SRCDIR}/test-bitnot.qasm > ${CMAKE_BINARY_DIR}/tests/test-bitnot.qasm.out 2>&1")


### PR DESCRIPTION
This PR adds the test-bitnot.qasm to tests/CMakeLists.txt so that the test will be run. 

Once run the test failed due to a segfault in ASTMangler.cpp. 

The `ASTOpTypeBitNot` was added to the mangler which fixed the test. 