### PR TITLE
Fix array access implicit conversion and add error diagnostics for out-of-bounds array accesses

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -92,6 +92,7 @@ class QasmConan(ConanFile):
         cmake = CMake(self)
         cmake.configure()
 
+        use_monitor = False
         if self.should_build:
             # Note that if a job does not produce output for a longer period of
             # time, then Travis will cancel that job.

--- a/include/qasm/AST/ASTArray.h
+++ b/include/qasm/AST/ASTArray.h
@@ -28,6 +28,8 @@
 #include <qasm/AST/OpenPulse/ASTOpenPulseFrame.h>
 #include <qasm/AST/OpenPulse/ASTOpenPulsePort.h>
 #include <qasm/AST/OpenPulse/ASTOpenPulseWaveform.h>
+#include <qasm/Diagnostic/DIAGLineCounter.h>
+#include <qasm/Frontend/QasmDiagnosticEmitter.h>
 
 #include <any>
 #include <sstream>
@@ -35,6 +37,8 @@
 #include <vector>
 
 namespace QASM {
+
+using DiagLevel = QASM::QasmDiagnosticEmitter::DiagLevel;
 
 class ASTArrayNode : public ASTExpressionNode {
 private:
@@ -65,6 +69,17 @@ public:
                unsigned Extents, const ASTInitializerList *IL = nullptr)
       : ASTExpressionNode(Id, ASTTypeArray), MM(), AType(ATy), SZ(Size),
         EXT(Extents), INL(IL) {}
+
+  /// Validate the array access, emitting a diagnostic if invalid.
+  void ValidateIndex(unsigned Index, QASM::ASTLocation location) const {
+    if (Index >= Size()) {
+      std::stringstream M;
+      M << "Array index " << Index << " out of range for array of size "
+        << Size() << ".";
+      QasmDiagnosticEmitter::Instance().EmitDiagnostic(location, M.str(),
+                                                       DiagLevel::Error);
+    }
+  }
 
   virtual ~ASTArrayNode() = default;
 
@@ -1689,7 +1704,6 @@ public:
   virtual unsigned GetElementSize() const override { return DB; }
 
   virtual ASTMPDecimalNode *GetElement(unsigned Index) {
-    assert(Index < MPV.size() && "Index is out-of-range!");
 
     try {
       return MPV.at(Index);

--- a/lib/AST/ASTBuilder.cpp
+++ b/lib/AST/ASTBuilder.cpp
@@ -4281,7 +4281,9 @@ ASTAngleNode *ASTBuilder::CreateASTAngleNodeFromExpression(
     ASTAngleArrayNode *AAN = ASTE->GetValue()->GetValue<ASTAngleArrayNode *>();
     assert(AAN && "Could not retrieve a valid ASTAngleArray Node from "
                   "the SymbolTable Entry!");
-    AN = AAN->GetElement(IdR->GetIndex());
+    auto Index = IdR->GetIndex();
+    AAN->ValidateIndex(Index, IdR->GetLocation());
+    AN = AAN->GetElement(Index);
     assert(AN && "Could not obtain a valid ASTAngleNode from the "
                  "ASTAngleArrayNode!");
   } break;

--- a/lib/AST/ASTGates.cpp
+++ b/lib/AST/ASTGates.cpp
@@ -250,12 +250,12 @@ ASTGateNode::CreateAngleConversion(const ASTSymbolTableEntry *XSTE) const {
     const ASTFloatNode *FN = XSTE->GetValue()->GetValue<ASTFloatNode *>();
     assert(FN && "Could not obtain a valid ASTFloatNode!");
 
-    XAN =
-        new ASTAngleNode(ASTIdentifierNode::Angle.Clone(LC), FN,
-                         ASTAngleTypeGeneric, XSTE->GetIdentifier()->GetBits());
+    unsigned ConvertBits = FN->GetBits();
+
+    XAN = new ASTAngleNode(ASTIdentifierNode::Angle.Clone(LC), FN,
+                           ASTAngleTypeGeneric, ConvertBits);
     assert(XAN && "Could not create a valid ASTAngleNode!");
-    ICE = new ASTImplicitConversionNode(FN, ASTTypeAngle,
-                                        XSTE->GetIdentifier()->GetBits());
+    ICE = new ASTImplicitConversionNode(FN, ASTTypeAngle, ConvertBits);
     assert(ICE && "Could not create a valid ASTImplicitConversionNode!");
     XAN->SetImplicitConversion(ICE);
   } break;
@@ -263,12 +263,12 @@ ASTGateNode::CreateAngleConversion(const ASTSymbolTableEntry *XSTE) const {
     const ASTDoubleNode *DN = XSTE->GetValue()->GetValue<ASTDoubleNode *>();
     assert(DN && "Could not obtain a valid ASTDoubleNode!");
 
-    XAN =
-        new ASTAngleNode(ASTIdentifierNode::Angle.Clone(LC), DN,
-                         ASTAngleTypeGeneric, XSTE->GetIdentifier()->GetBits());
+    unsigned ConvertBits = DN->GetBits();
+
+    XAN = new ASTAngleNode(ASTIdentifierNode::Angle.Clone(LC), DN,
+                           ASTAngleTypeGeneric, ConvertBits);
     assert(XAN && "Could not create a valid ASTAngleNode!");
-    ICE = new ASTImplicitConversionNode(DN, ASTTypeAngle,
-                                        XSTE->GetIdentifier()->GetBits());
+    ICE = new ASTImplicitConversionNode(DN, ASTTypeAngle, ConvertBits);
     assert(ICE && "Could not create a valid ASTImplicitConversionNode!");
     XAN->SetImplicitConversion(ICE);
   } break;
@@ -277,12 +277,12 @@ ASTGateNode::CreateAngleConversion(const ASTSymbolTableEntry *XSTE) const {
     const ASTIntNode *IN = XSTE->GetValue()->GetValue<ASTIntNode *>();
     assert(IN && "Could not obtain a valid ASTIntNode!");
 
-    XAN =
-        new ASTAngleNode(ASTIdentifierNode::Angle.Clone(LC), IN,
-                         ASTAngleTypeGeneric, XSTE->GetIdentifier()->GetBits());
+    unsigned ConvertBits = IN->GetBits();
+
+    XAN = new ASTAngleNode(ASTIdentifierNode::Angle.Clone(LC), IN,
+                           ASTAngleTypeGeneric, ConvertBits);
     assert(XAN && "Could not create a valid ASTAngleNode!");
-    ICE = new ASTImplicitConversionNode(IN, ASTTypeAngle,
-                                        XSTE->GetIdentifier()->GetBits());
+    ICE = new ASTImplicitConversionNode(IN, ASTTypeAngle, ConvertBits);
     assert(ICE && "Could not create a valid ASTImplicitConversionNode!");
     XAN->SetImplicitConversion(ICE);
   } break;
@@ -292,12 +292,12 @@ ASTGateNode::CreateAngleConversion(const ASTSymbolTableEntry *XSTE) const {
         XSTE->GetValue()->GetValue<ASTMPIntegerNode *>();
     assert(MPI && "Could not obtain a valid ASTMPIntegerNode!");
 
-    XAN =
-        new ASTAngleNode(ASTIdentifierNode::Angle.Clone(LC), MPI,
-                         ASTAngleTypeGeneric, XSTE->GetIdentifier()->GetBits());
+    unsigned ConvertBits = MPI->GetBits();
+
+    XAN = new ASTAngleNode(ASTIdentifierNode::Angle.Clone(LC), MPI,
+                           ASTAngleTypeGeneric, ConvertBits);
     assert(XAN && "Could not create a valid ASTAngleNode!");
-    ICE = new ASTImplicitConversionNode(MPI, ASTTypeAngle,
-                                        XSTE->GetIdentifier()->GetBits());
+    ICE = new ASTImplicitConversionNode(MPI, ASTTypeAngle, ConvertBits);
     assert(ICE && "Could not create a valid ASTImplicitConversionNode!");
     XAN->SetImplicitConversion(ICE);
   } break;
@@ -306,12 +306,12 @@ ASTGateNode::CreateAngleConversion(const ASTSymbolTableEntry *XSTE) const {
         XSTE->GetValue()->GetValue<ASTMPDecimalNode *>();
     assert(MPD && "Could not obtain a valid ASTMPDecimalNode!");
 
-    XAN =
-        new ASTAngleNode(ASTIdentifierNode::Angle.Clone(LC), MPD,
-                         ASTAngleTypeGeneric, XSTE->GetIdentifier()->GetBits());
+    unsigned ConvertBits = MPD->GetBits();
+
+    XAN = new ASTAngleNode(ASTIdentifierNode::Angle.Clone(LC), MPD,
+                           ASTAngleTypeGeneric, ConvertBits);
     assert(XAN && "Could not create a valid ASTAngleNode!");
-    ICE = new ASTImplicitConversionNode(MPD, ASTTypeAngle,
-                                        XSTE->GetIdentifier()->GetBits());
+    ICE = new ASTImplicitConversionNode(MPD, ASTTypeAngle, ConvertBits);
     assert(ICE && "Could not create a valid ASTImplicitConversionNode!");
     XAN->SetImplicitConversion(ICE);
   } break;
@@ -319,7 +319,9 @@ ASTGateNode::CreateAngleConversion(const ASTSymbolTableEntry *XSTE) const {
     const ASTCBitNode *CBN = XSTE->GetValue()->GetValue<ASTCBitNode *>();
     assert(CBN && "Could not obtain a valid ASTCBitNode!");
 
-    if (CBN->Size() > XSTE->GetIdentifier()->GetBits()) {
+    unsigned ConvertBits = CBN->GetBits();
+
+    if (CBN->Size() > ConvertBits) {
       std::stringstream M;
       M << "Conversion from " << PrintTypeEnum(XSTE->GetValueType())
         << " to Angle Type will result in truncation.";
@@ -328,8 +330,7 @@ ASTGateNode::CreateAngleConversion(const ASTSymbolTableEntry *XSTE) const {
           M.str(), DiagLevel::Warning);
     }
 
-    unsigned SZ = std::min(static_cast<unsigned>(CBN->Size()),
-                           XSTE->GetIdentifier()->GetBits());
+    unsigned SZ = std::min(static_cast<unsigned>(CBN->Size()), ConvertBits);
 
     if (SZ >= 4U)
       SZ = SZ % 4;
@@ -340,9 +341,8 @@ ASTGateNode::CreateAngleConversion(const ASTSymbolTableEntry *XSTE) const {
       if ((*CBN)[I])
         D += static_cast<double>(M_PI / 2);
 
-    XAN =
-        new ASTAngleNode(ASTIdentifierNode::Angle.Clone(LC), D,
-                         ASTAngleTypeGeneric, XSTE->GetIdentifier()->GetBits());
+    XAN = new ASTAngleNode(ASTIdentifierNode::Angle.Clone(LC), D,
+                           ASTAngleTypeGeneric, ConvertBits);
     assert(XAN && "Could not create a valid ASTAngleNode!");
     ICE = new ASTImplicitConversionNode(CBN, ASTTypeAngle, SZ);
     assert(ICE && "Could not create a valid ASTImplicitConversionNode!");

--- a/lib/AST/ASTOpenPulseFrame.cpp
+++ b/lib/AST/ASTOpenPulseFrame.cpp
@@ -238,6 +238,7 @@ ASTOpenPulseFrameNodeResolver::ResolveAngle(ASTExpressionNode *E) {
             ASTE->GetValue()->GetValue<ASTFloatArrayNode *>();
         assert(FAN && "Could not obtain a valid ASTFloatArrayNode "
                       "from the SymbolTable!");
+        FAN->ValidateIndex(IX, AIdR->GetLocation());
         ASTFloatNode *FN = FAN->GetElement(IX);
         assert(FN && "Could not obtain a valid ASTFloatNode "
                      "from the ASTFloat array!");
@@ -250,6 +251,8 @@ ASTOpenPulseFrameNodeResolver::ResolveAngle(ASTExpressionNode *E) {
             ASTE->GetValue()->GetValue<ASTMPDecimalArrayNode *>();
         assert(MPAN && "Could not obtain a valid ASTMPDecimalArrayNode "
                        "from the SymbolTable!");
+
+        MPAN->ValidateIndex(IX, AIdR->GetLocation());
         ASTMPDecimalNode *MPD = MPAN->GetElement(IX);
         assert(MPD && "Could not obtain a valid ASTMPDecimalNode "
                       "from the ASTMPDecimal array!");
@@ -262,6 +265,7 @@ ASTOpenPulseFrameNodeResolver::ResolveAngle(ASTExpressionNode *E) {
             ASTE->GetValue()->GetValue<ASTAngleArrayNode *>();
         assert(AAN && "Could not obtain a valid ASTAngleArrayNode "
                       "from the SymbolTable!");
+        AAN->ValidateIndex(IX, AIdR->GetLocation());
         AN = AAN->GetElement(IX);
         assert(AN && "Could not obtain a valid ASTAngleNode "
                      "from the ASTAngle array!");
@@ -556,6 +560,7 @@ ASTOpenPulseFrameNodeResolver::ResolveFrequency(ASTExpressionNode *E) {
             DSTE->GetValue()->GetValue<ASTFloatArrayNode *>();
         assert(FAN && "Could not obtain a valid ASTFloatArrayNode "
                       "from the SymbolTable!");
+        FAN->ValidateIndex(IX, DIdR->GetLocation());
         ASTFloatNode *FN = FAN->GetElement(IX);
         assert(FN && "Could not obtain a valid ASTFloatNode "
                      "from the ASTFloat array!");
@@ -567,6 +572,7 @@ ASTOpenPulseFrameNodeResolver::ResolveFrequency(ASTExpressionNode *E) {
             DSTE->GetValue()->GetValue<ASTMPDecimalArrayNode *>();
         assert(MPDA && "Could not obtain a valid ASTMPDecimalArrayNode "
                        "from the SymbolTable!");
+        MPDA->ValidateIndex(IX, DIdR->GetLocation());
         ASTMPDecimalNode *MPDD = MPDA->GetElement(IX);
         assert(MPDD && "Could not obtain a valid ASTMPDecimalNode "
                        "from the ASTMPDecimal array!");
@@ -577,6 +583,7 @@ ASTOpenPulseFrameNodeResolver::ResolveFrequency(ASTExpressionNode *E) {
             DSTE->GetValue()->GetValue<ASTMPIntegerArrayNode *>();
         assert(MPIA && "Could not obtain a valid ASTMPIntegerArrayNode "
                        "from the SymbolTable!");
+        MPIA->ValidateIndex(IX, DIdR->GetLocation());
         ASTMPIntegerNode *MPI = MPIA->GetElement(IX);
         assert(MPI && "Could not obtain a valid ASTMPIntegerNode "
                       "from the ASTMPInteger array!");

--- a/lib/AST/ASTProductionFactory.cpp
+++ b/lib/AST/ASTProductionFactory.cpp
@@ -892,6 +892,7 @@ ASTProductionFactory::ProductionRule_105(const ASTToken *TK,
     ASTIntArrayNode *IAN = dynamic_cast<ASTIntArrayNode *>(
         STE->GetValue()->GetValue<ASTArrayNode *>());
     assert(IAN && "Invalid Value obtained from the SymbolTable Entry!");
+    IAN->ValidateIndex(Index, Id->GetLocation());
     ASTIntNode *IN = IAN->GetElement(Index);
     assert(IN && "Invalid ASTIntNode obtained from the SymbolTable Entry!");
     BV = ASTUtils::Instance().GetBooleanValue(IN);
@@ -900,6 +901,7 @@ ASTProductionFactory::ProductionRule_105(const ASTToken *TK,
     ASTMPIntegerArrayNode *MPIA = dynamic_cast<ASTMPIntegerArrayNode *>(
         STE->GetValue()->GetValue<ASTArrayNode *>());
     assert(MPIA && "Invalid Value obtained from the SymbolTable Entry!");
+    MPIA->ValidateIndex(Index, Id->GetLocation());
     ASTMPIntegerNode *MPI = MPIA->GetElement(Index);
     assert(MPI &&
            "Invalid ASTMPIntegerNode obtained from the SymbolTable Entry!");
@@ -909,6 +911,7 @@ ASTProductionFactory::ProductionRule_105(const ASTToken *TK,
     ASTBoolArrayNode *BAN = dynamic_cast<ASTBoolArrayNode *>(
         STE->GetValue()->GetValue<ASTArrayNode *>());
     assert(BAN && "Invalid Value obtained from the SymbolTable Entry!");
+    BAN->ValidateIndex(Index, Id->GetLocation());
     ASTBoolNode *BN = BAN->GetElement(Index);
     assert(BN && "Invalid ASTBoolNode obtained from the SymbolTable Entry!");
     BV = BN->GetValue();
@@ -917,6 +920,7 @@ ASTProductionFactory::ProductionRule_105(const ASTToken *TK,
     ASTCBitArrayNode *CBA = dynamic_cast<ASTCBitArrayNode *>(
         STE->GetValue()->GetValue<ASTArrayNode *>());
     assert(CBA && "Invalid Value obtained from the SymbolTable Entry!");
+    CBA->ValidateIndex(Index, Id->GetLocation());
     ASTCBitNode *CBN = CBA->GetElement(Index);
     assert(CBN && "Invalid ASTCBitNode obtained from the SymbolTable Entry!");
     BV = CBN->AsBool();
@@ -925,6 +929,7 @@ ASTProductionFactory::ProductionRule_105(const ASTToken *TK,
     ASTCBitNArrayNode *CBNA = dynamic_cast<ASTCBitNArrayNode *>(
         STE->GetValue()->GetValue<ASTArrayNode *>());
     assert(CBNA && "Invalid Value obtained from the SymbolTable Entry!");
+    CBNA->ValidateIndex(Index, Id->GetLocation());
     ASTCBitNode *CBN = CBNA->GetElement(Index);
     assert(CBN && "Invalid ASTCBitNode obtained from the SymbolTable Entry!");
     BV = CBN->AsBool();
@@ -1322,7 +1327,9 @@ ASTProductionFactory::ProductionRule_110(const ASTToken *TK,
         assert(CRN && "Could not obtain a valid ASTCBitArrayNode from "
                       "the SymbolTable!");
 
-        CBN = CRN->GetElement(IdR->GetIndex());
+        auto Index = IdR->GetIndex();
+        CRN->ValidateIndex(Index, IdR->GetLocation());
+        CBN = CRN->GetElement(Index);
         assert(CBN && "Could not obtain a valid ASTCBitNode from "
                       "the ASTCBitArrayNode!");
         FromArray = true;
@@ -1334,7 +1341,9 @@ ASTProductionFactory::ProductionRule_110(const ASTToken *TK,
         assert(CRN && "Could not obtain a valid ASTCBitNArrayNode from "
                       "the SymbolTable!");
 
-        CBN = CRN->GetElement(IdR->GetIndex());
+        auto Index = IdR->GetIndex();
+        CRN->ValidateIndex(Index, IdR->GetLocation());
+        CBN = CRN->GetElement(Index);
         assert(CBN && "Could not obtain a valid ASTCBitNode from "
                       "the ASTCBitNArrayNode!");
         FromArray = true;
@@ -16661,7 +16670,9 @@ ASTDurationNode *ASTProductionFactory::ProductionRule_1202(
             LSTE->GetValue()->GetValue<ASTArrayNode *>());
         assert(DAN && "Could not dynamic_cast to an ASTDurationArrayNode!");
 
-        DRN = DAN->GetElement(IdR->GetIndex());
+        auto Index = IdR->GetIndex();
+        DAN->ValidateIndex(Index, IdR->GetLocation());
+        DRN = DAN->GetElement(Index);
         assert(DRN && "Could not obtain a valid ASTDurationNode from "
                       "the ASTDurationArrayNode!");
         LS = DRN->AsString();
@@ -16692,7 +16703,9 @@ ASTDurationNode *ASTProductionFactory::ProductionRule_1202(
           LSTE->GetValue()->GetValue<ASTArrayNode *>());
       assert(DAN && "Could not dynamic_cast to an ASTDurationArrayNode!");
 
-      DRN = DAN->GetElement(Id->GetBits());
+      auto Index = Id->GetBits();
+      DAN->ValidateIndex(Index, Id->GetLocation());
+      DRN = DAN->GetElement(Index);
       assert(DRN && "Could not obtain a valid ASTDurationNode from "
                     "the ASTLengthArrayNode!");
       LS = DRN->AsString();
@@ -16791,7 +16804,9 @@ ASTDurationNode *ASTProductionFactory::ProductionRule_1203(
             LSTE->GetValue()->GetValue<ASTArrayNode *>());
         assert(DAN && "Could not dynamic_cast to an ASTLengthArrayNode!");
 
-        DRN = DAN->GetElement(IdR->GetIndex());
+        auto Index = IdR->GetIndex();
+        DAN->ValidateIndex(Index, IdR->GetLocation());
+        DRN = DAN->GetElement(Index);
         assert(DRN && "Could not obtain a valid ASTDurationNode from "
                       "the ASTDurationArrayNode!");
         LS = DRN->AsString();
@@ -16822,7 +16837,9 @@ ASTDurationNode *ASTProductionFactory::ProductionRule_1203(
           LSTE->GetValue()->GetValue<ASTArrayNode *>());
       assert(DAN && "Could not dynamic_cast to an ASTLengthArrayNode!");
 
-      DRN = DAN->GetElement(Id->GetBits());
+      auto Index = Id->GetBits();
+      DAN->ValidateIndex(Index, Id->GetLocation());
+      DRN = DAN->GetElement(Index);
       assert(DRN && "Could not obtain a valid ASTDurationNode from "
                     "the ASTDurationArrayNode!");
       LS = DRN->AsString();
@@ -17968,7 +17985,9 @@ ASTProductionFactory::ProductionRule_1103(const ASTToken *TK,
         STE->GetValue()->GetValue<ASTArrayNode *>());
     assert(QAN && "Could not retrieve a valid ASTQubitArrayNode!");
 
-    QCN = QAN->GetElement(QId->GetBits());
+    auto Index = QId->GetBits();
+    QAN->ValidateIndex(Index, QId->GetLocation());
+    QCN = QAN->GetElement(Index);
     assert(QCN && "Could not dynamic_cast to an ASTQubitContainerNode!");
   } break;
   case ASTTypeQubitContainer: {
@@ -18204,7 +18223,9 @@ ASTDeclarationNode *ASTProductionFactory::ProductionRule_1106(
         STE->GetValue()->GetValue<ASTArrayNode *>());
     assert(QAN && "Could not retrieve a valid ASTQubitArrayNode!");
 
-    QCN = QAN->GetElement(QId->GetBits());
+    auto Index = QId->GetBits();
+    QAN->ValidateIndex(Index, QId->GetLocation());
+    QCN = QAN->GetElement(Index);
     assert(QCN && "Could not dynamic_cast to an ASTQubitContainerNode!");
   } break;
   case ASTTypeQubitContainer: {
@@ -22158,6 +22179,7 @@ ASTProductionFactory::ProductionRule_1461(const ASTToken *TK,
       unsigned I = RIdR ? RIdR->GetIndex() : RId->GetBits();
       assert(I != static_cast<unsigned>(~0x0) &&
              "Invalid ASTCBitArrayNode Index!");
+      CAN->ValidateIndex(I, RIdR ? RIdR->GetLocation() : RId->GetLocation());
       CBN = CAN->GetElement(I);
       assert(CBN && "Invalid Bitset obtained from the ASTCBitArrayNode!");
       RTy = CBN->GetASTType();
@@ -22169,6 +22191,7 @@ ASTProductionFactory::ProductionRule_1461(const ASTToken *TK,
       unsigned I = RIdR ? RIdR->GetIndex() : RId->GetBits();
       assert(I != static_cast<unsigned>(~0x0) &&
              "Invalid ASTCBitArrayNode Index!");
+      CAN->ValidateIndex(I, RIdR ? RIdR->GetLocation() : RId->GetLocation());
       CBN = CAN->GetElement(I);
       assert(CBN && "Invalid Bitset obtained from the ASTCBitNArrayNode!");
       RTy = CBN->GetASTType();

--- a/lib/AST/ASTTypeDiscovery.cpp
+++ b/lib/AST/ASTTypeDiscovery.cpp
@@ -2159,6 +2159,7 @@ ASTIdentifierRefNode *ResolveASTIdentifierRef(
   __AT *A = dynamic_cast<__AT *>(STE->GetValue()->GetValue<ASTArrayNode *>());
   assert(A && "Could not dynamic_cast to a valid array node!");
 
+  A->ValidateIndex(IX, ASN->GetLocation());
   __ET *E = A->GetElement(IX);
   assert(E && "Could not obtain a valid array element!");
 

--- a/lib/AST/ASTUtils.cpp
+++ b/lib/AST/ASTUtils.cpp
@@ -69,7 +69,9 @@ unsigned ASTUtils::GetUnsignedValue(const ASTIdentifierNode *Id) const {
           STE->GetValue()->GetValue<ASTArrayNode *>());
       assert(BAN && "Could not dynamic_cast to an ASTBoolArrayNode!");
 
-      ASTBoolNode *B = BAN->GetElement(IdR->GetIndex());
+      auto Index = IdR->GetIndex();
+      BAN->ValidateIndex(Index, IdR->GetLocation());
+      ASTBoolNode *B = BAN->GetElement(Index);
       assert(B && "Could not obtain a valid SymbolTable Entry Value!");
 
       return static_cast<unsigned>(B->GetValue());
@@ -79,7 +81,9 @@ unsigned ASTUtils::GetUnsignedValue(const ASTIdentifierNode *Id) const {
           STE->GetValue()->GetValue<ASTArrayNode *>());
       assert(IAN && "Could not dynamic_cast to an ASTIntArrayNode!");
 
-      ASTIntNode *I = IAN->GetElement(IdR->GetIndex());
+      auto Index = IdR->GetIndex();
+      IAN->ValidateIndex(Index, IdR->GetLocation());
+      ASTIntNode *I = IAN->GetElement(Index);
       assert(I && "Could not obtain a valid SymbolTable Entry Value!");
 
       return I->IsSigned() ? static_cast<unsigned>(I->GetSignedValue())
@@ -90,7 +94,9 @@ unsigned ASTUtils::GetUnsignedValue(const ASTIdentifierNode *Id) const {
           STE->GetValue()->GetValue<ASTArrayNode *>());
       assert(FAN && "Could not dynamic_cast to an ASTFloatArrayNode!");
 
-      ASTFloatNode *F = FAN->GetElement(IdR->GetIndex());
+      auto Index = IdR->GetIndex();
+      FAN->ValidateIndex(Index, IdR->GetLocation());
+      ASTFloatNode *F = FAN->GetElement(Index);
       assert(F && "Could not obtain a valid SymbolTable Entry Value!");
 
       return static_cast<unsigned>(F->GetValue());
@@ -100,7 +106,9 @@ unsigned ASTUtils::GetUnsignedValue(const ASTIdentifierNode *Id) const {
           STE->GetValue()->GetValue<ASTArrayNode *>());
       assert(MIAN && "Could not dynamic_cast to an ASTMPIntegerArrayNode!");
 
-      ASTMPIntegerNode *MPI = MIAN->GetElement(IdR->GetIndex());
+      auto Index = IdR->GetIndex();
+      MIAN->ValidateIndex(Index, IdR->GetLocation());
+      ASTMPIntegerNode *MPI = MIAN->GetElement(Index);
       assert(MPI && "Could not obtain a valid SymbolTable Entry Value!");
 
       return MPI->ToUnsignedInt();
@@ -110,7 +118,9 @@ unsigned ASTUtils::GetUnsignedValue(const ASTIdentifierNode *Id) const {
           STE->GetValue()->GetValue<ASTArrayNode *>());
       assert(MDAN && "Could not dynamic_cast to an ASTMPDecimalArrayNode!");
 
-      ASTMPDecimalNode *MPD = MDAN->GetElement(IdR->GetIndex());
+      auto Index = IdR->GetIndex();
+      MDAN->ValidateIndex(Index, IdR->GetLocation());
+      ASTMPDecimalNode *MPD = MDAN->GetElement(Index);
       assert(MPD && "Could not obtain a valid SymbolTable Entry Value!");
 
       return static_cast<unsigned>(MPD->ToDouble());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -680,3 +680,7 @@ add_test(NAME t00335
          COMMAND ${BASH} -c "${OPENQASM_TEST_PROGRAM} -I${OPENQASM_TEST_INCDIR} ${OPENQASM_TEST_SRCDIR}/test-nested-elseif.qasm > ${CMAKE_BINARY_DIR}/tests/test-nested-elseif.qasm.out 2>&1")
 add_test(NAME t00336
          COMMAND ${BASH} -c "${OPENQASM_TEST_PROGRAM} -I${OPENQASM_TEST_INCDIR} ${OPENQASM_TEST_SRCDIR}/test-multi-nested-elseif.qasm > ${CMAKE_BINARY_DIR}/tests/test-multi-nested-elseif.qasm.out 2>&1")
+add_test(NAME t00337
+         COMMAND ${BASH} -c "${OPENQASM_TEST_PROGRAM} -I${OPENQASM_TEST_INCDIR} ${OPENQASM_TEST_SRCDIR}/test-array-17.qasm > ${CMAKE_BINARY_DIR}/tests/test-array-17.qasm.out 2>&1")
+add_test(NAME t00338
+         COMMAND ${BASH} -c "${OPENQASM_TEST_PROGRAM} -I${OPENQASM_TEST_INCDIR} ${OPENQASM_TEST_SRCDIR}/test-array-18.qasm > ${CMAKE_BINARY_DIR}/tests/test-array-18.qasm.out 2>&1")

--- a/tests/src/test-array-17.qasm
+++ b/tests/src/test-array-17.qasm
@@ -1,0 +1,21 @@
+OPENQASM 3.0;
+
+
+gate phase(lambda) q {
+  U(0, 0, lambda) q;
+}
+
+qubit a;
+
+array[qubit, 16] aarray;
+
+input array[angle, 16] aa;
+
+
+phase(aa[0]) a;
+
+phase(aa[0]) aarray;
+
+angle assign = aa[0];
+
+phase(assign) a;

--- a/tests/src/test-array-18.qasm
+++ b/tests/src/test-array-18.qasm
@@ -1,0 +1,26 @@
+OPENQASM 3;
+
+gate rz(theta) q {}
+
+qubit $0;
+
+input angle angle_p;
+input float[64] float_p;
+
+input array[angle, 20000] array_angle_p;
+input array[float[64], 20000] array_float_p;
+
+// Access value directly
+rz(angle_p) $0;
+rz(float_p) $0;
+
+// Access value through array reference
+rz(array_angle_p[0]) $0;
+rz(array_float_p[0]) $0;
+
+// Access value through intermediate assignment
+float[64] intermediate_angle = array_angle_p[0];
+float[64] intermediate_float = array_float_p[0];
+
+rz(intermediate_angle);
+rz(intermediate_float);

--- a/tests/src/test-array-18.qasm
+++ b/tests/src/test-array-18.qasm
@@ -7,8 +7,8 @@ qubit $0;
 input angle angle_p;
 input float[64] float_p;
 
-input array[angle, 20000] array_angle_p;
-input array[float[64], 20000] array_float_p;
+input array[angle, 10] array_angle_p;
+input array[float[64], 10] array_float_p;
 
 // Access value directly
 rz(angle_p) $0;
@@ -16,11 +16,12 @@ rz(float_p) $0;
 
 // Access value through array reference
 rz(array_angle_p[0]) $0;
+rz(array_angle_p[1]) $0;
 rz(array_float_p[0]) $0;
+rz(array_float_p[1]) $0;
 
 // Access value through intermediate assignment
 float[64] intermediate_angle = array_angle_p[0];
 float[64] intermediate_float = array_float_p[0];
-
-rz(intermediate_angle);
-rz(intermediate_float);
+rz(intermediate_angle) $0;
+rz(intermediate_float) $0;


### PR DESCRIPTION
This PR fixes an issue with using arrays as inputs to gates and provides an accompanying test. It also adds an error diagnostic to check for out-of-bounds array accesses.