### PR TITLE
fix(parser): reset stream position for direct string input, close #35

### DIFF
--- a/lib/Parser/QasmParser.y
+++ b/lib/Parser/QasmParser.y
@@ -384,6 +384,11 @@ int yyparse() {
     if (OQ != "OPENQASM" || OV.empty())
       QASM::ASTOpenQASMVersionTracker::Instance().SetVersion(3.0);
 
+    if (IIS) {
+      IIS->clear();
+      IIS->seekg(0, std::ios::beg);
+    }
+
     if (!QASM::QasmPreprocessor::Instance().Preprocess(IIS)) {
       std::stringstream M;
       M << "OpenQASM Preprocessor failure!";


### PR DESCRIPTION
Hi Team,

The root cause of https://github.com/openqasm/qe-qasm/issues/35 is as follows

https://github.com/openqasm/qe-qasm/blob/main/lib/Parser/QasmParser.y#L338-L342

Here `IIS` and `ISS` points to the same buffer, as `std::getline` moves the pointer to the next line, we got the wrong line number when directly parsing string.

Thus we just need to reset the position of `IIS` to make `QASM::QasmPreprocessor::Instance().Preprocess(IIS)` work as expected


I did not find any test codes in this repo to directly test `QasmParser.y`. I'm willing to add some tests and wish to know the proper way to do so. 

Thanks,
Yilun

