### PR TITLE
Migrate the build to Conan 2.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+
 name: Continuous Integration
 on: [push, pull_request]
 jobs:
@@ -41,15 +42,16 @@ jobs:
           restore-keys: conan-${{ runner.os }}
       - name: Create Conan default profile
         run: |
-          conan profile new default --detect || true
-          conan profile update settings.compiler.libcxx=libstdc++11 default
+          conan profile detect --name default --exist-ok
+          sed -i 's/compiler.libcxx=.*/compiler.libcxx=libstdc++11/' $(conan profile path default)
       # Check if all conan packages are within the cache. If not
       # we will need to build packages (and if on main flush the cache)
-      - name : Check Conan dependencies are cached
+      - name: Check Conan dependencies are cached
         id: check_conan_cache
         run: |
           export CONAN_LLVM_GIT_CACHE="${{ runner.temp }}/llvm-project"
-          conan info . -pr:h default -pr:b default --build=outdated --json build_requires.json
+          conan graph info . -pr:h default -pr:b default --build=outdated --format=json > build_requires.json
+
           build_requires=$(cat build_requires.json)
           if [[ "$build_requires" == *"[]"* ]];
           then
@@ -63,18 +65,18 @@ jobs:
       # If we have a cache miss on 'main', clear the cache.
       # A dependency was updated, so we need to drop the old one
       # to prevent unbounded cache growth over time.
-      - name : Clear Conan cache
+      - name: Clear Conan cache
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.check_conan_cache.outputs.all_in_cache != 'true'
         run: |
           rm -rf ./.conan
           # Re-add conan deps after flushing the conan cache before building packages.
-          conan profile new default --detect || true
-          conan profile update settings.compiler.libcxx=libstdc++11 default
+          conan profile detect --name default --exist-ok
+          sed -i 's/compiler.libcxx=.*/compiler.libcxx=libstdc++11/' $(conan profile path default)
       # Installs dependencies, builds, tests and packages
       - name: Create Conan Package
         id: conan_create
         run: |
-          conan create . openqasm/stable --build=outdated -pr:h default -pr:b default
+          conan create . --name=qe-qasm --build=missing -pr:h default -pr:b default
       # On 'main' branch, always save the cache if Conan install succeeded.
       # Note: we only update the cache from 'main' to avoid "cache thrashing", which would result in the 'main'
       #       cache getting LRU-evicted for every PR, since a single run uses most of the 10GB repo limit.

--- a/README.md
+++ b/README.md
@@ -45,15 +45,17 @@ Currently the supported platforms are Linux and OSX. It is possible to build on 
 - Clone this repo: `git clone git@github.com:openqasm/qe-qasm.git`
 - Install build dependencies: `pip install -r requirements-dev.txt`
   - It is recommended to use a Python virtual environment for this
+- Generate conan profile with `conan profile detect --name default --exist-ok`
+- Inspect settings in the `default` profile with `cat $(conan profile path default)`
 - The package may be built and installed to conan with: `conan create . --build=outdated -pr:h default -pr:b default`
    - This will build the conan package and install it locally. The version will be detected automatically from the repo tag.
-   - If you wish to override the package name, version or remote do so by calling conan with `conan create . <package>/<version>@remote -pr:h default -pr:b default`
+   - If you wish to override the package name, version or remote do so by calling conan with `conan create . --name=<name> --version=<version> --remote=<remote> -pr:h default -pr:b default`
 
 #### Building for development and debugging
 - Create a build directory: `mkdir build && cd build/`
 - Install package with: `conan install .. --build=outdated -pr:h default -pr:b default` which will install and build all missing dependencies
 - Build the package with: `conan build ..`
-- The package tests may be run with: `conan build .. --test`
+- The package tests may be run with: `conan test ..`
 
 
 ### Make

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,6 +1,6 @@
 requirements:
   - "gmp/6.3.0"
-  - "mpfr/4.2.1"
+  - "mpfr/4.2.0"
   - "mpc/1.3.1"
   - "bison/3.8.2"
   - "flex/2.6.4"

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,9 +13,9 @@ import os
 import platform
 import subprocess
 
-from conans import ConanFile
-from conans.tools import save
+from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import save, copy
 from setuptools_scm import get_version as get_version_scm
 
 
@@ -36,9 +36,9 @@ class QasmConan(ConanFile):
         "shared": False,
         "examples": True,
         # Enforce dynamic linking against LGPL dependencies
-        "gmp:shared": True,
-        "mpc:shared": True,
-        "mpfr:shared": True,
+        "gmp/*:shared": True,
+        "mpc/*:shared": True,
+        "mpfr/*:shared": True,
     }
     license = "Apache-2.0"
     author = "OpenQASM Organization"
@@ -46,13 +46,16 @@ class QasmConan(ConanFile):
     description = "A flex/bison parser for OpenQASM v3. A part of the Quantum Engine project."
     generators = "CMakeDeps"
 
+    def set_version(self):
+        self.version = get_version() or "0.0.0"
+
     def requirements(self):
         # Private deps won't be linked against by consumers, which is important
         # at least for Flex which does not expose a CMake target.
         private_deps = ["bison", "flex"]
         for req in self.conan_data["requirements"]:
             private = any(req.startswith(d) for d in private_deps)
-            self.requires(req, private=private)
+            self.requires(req, visible=not private)
 
     def build_requirements(self):
         for req in self.conan_data["build_requirements"]:
@@ -74,9 +77,9 @@ class QasmConan(ConanFile):
             "VERSION.txt",
         ]
         for source in sources:
-            self.copy(source)
+            copy(self, source, src=self.recipe_folder, dst=self.export_sources_folder)
 
-        save(os.path.join(self.export_sources_folder, "VERSION.txt"), self.version)
+        save(self, os.path.join(self.export_sources_folder, "VERSION.txt"), self.version)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -92,34 +95,42 @@ class QasmConan(ConanFile):
         cmake = CMake(self)
         cmake.configure()
 
-        use_monitor = False
-        if self.should_build:
-            # Note that if a job does not produce output for a longer period of
-            # time, then Travis will cancel that job.
-            # Avoid that timeout by running vmstat in the background, which reports
-            # free memory and other stats every 30 seconds.
-            use_monitor = platform.system() == "Linux"
-            if use_monitor:
-                subprocess.run("free -h ; lscpu", shell=True)
-                monitor = subprocess.Popen(["vmstat", "-w", "30", "-t"])
-            cmake.build()
+        # Note that if a job does not produce output for a longer period of
+        # time, then Travis will cancel that job.
+        # Avoid that timeout by running vmstat in the background, which reports
+        # free memory and other stats every 30 seconds.
+        use_monitor = platform.system() == "Linux"
+        if use_monitor:
+            subprocess.run("free -h ; lscpu", shell=True)
+            monitor = subprocess.Popen(["vmstat", "-w", "30", "-t"])
+
+        cmake.build()
+
         if use_monitor:
             monitor.terminate()
             monitor.wait(1)
 
-        if self.should_test:
-            self.test(cmake)
-
-    def test(self, cmake):
+    def test(self):
         # Tests require examples to be built
         if self.options.examples:
+            cmake = CMake(self)
             cmake.test(target="test")
 
     def package(self):
         cmake = CMake(self)
         cmake.install()
-        self.copy("*.tab.cpp", dst="include/lib/Parser", src="lib/Parser")
-        self.copy("*.tab.h", dst="include/lib/Parser", src="lib/Parser")
+        copy(
+            self,
+            "*.tab.cpp",
+            src=os.path.join(self.source_folder, "lib/Parser"),
+            dst=os.path.join(self.package_folder, "include/lib/Parser"),
+        )
+        copy(
+            self,
+            "*.tab.h",
+            src=os.path.join(self.source_folder, "lib/Parser"),
+            dst=os.path.join(self.package_folder, "include/lib/Parser"),
+        )
 
     def package_info(self):
         self.cpp_info.set_property("cmake_find_mode", "both")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 cmake
-conan<2.0
+conan>=2.0
 pre-commit
 setuptools_scm>=6.0,<8.0


### PR DESCRIPTION
Hey @steleman, @steleman, @openqasm/qe-maintainers,

I Found a few issues getting started on the project. As I got lots of warnings and errors about Conan 1 deprecations, I thought it's a good first step to try and migrate the build to latest Conan.

Changes are also reflected on the CI pipeline, which should be running fine.